### PR TITLE
Use undertow-pac4j 1.0.0 instead of 1.0.0-snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.pac4j</groupId>
 			<artifactId>undertow-pac4j</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
+			<version>1.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.pac4j</groupId>


### PR DESCRIPTION
With the original pom.xml I got
```
Failed to execute goal on project undertow-pac4j-demo: Could not resolve dependencies for project org.pac4j:undertow-pac4j-demo:jar:1.0.0-SNAPSHOT: 
Could not find artifact org.pac4j:undertow-pac4j:jar:1.0.0-SNAPSHOT in sonatype-nexus-snapshots
```